### PR TITLE
Prevent VirtualBox from interfering with host audio stack

### DIFF
--- a/vagrant-provisioning/Vagrantfile
+++ b/vagrant-provisioning/Vagrantfile
@@ -16,6 +16,8 @@ Vagrant.configure(2) do |config|
       v.name = "kmaster"
       v.memory = 2048
       v.cpus = 2
+      # Prevent VirtualBox from interfering with host audio stack
+      v.customize ["modifyvm", :id, "--audio", "none"]
     end
     kmaster.vm.provision "shell", path: "bootstrap_kmaster.sh"
   end
@@ -32,6 +34,8 @@ Vagrant.configure(2) do |config|
         v.name = "kworker#{i}"
         v.memory = 1024
         v.cpus = 1
+        # Prevent VirtualBox from interfering with host audio stack
+        v.customize ["modifyvm", :id, "--audio", "none"]
       end
       workernode.vm.provision "shell", path: "bootstrap_kworker.sh"
     end


### PR DESCRIPTION
Hi @justmeandopensource,

Thanks for this very useful repository. I just found out that the default VM configuration could interfere with the host audio stack, that's why I suggest to disable audio on the VMs.

Thanks!