### PR TITLE
Fixing deployment resources for to work with Kube 1.16.2

### DIFF
--- a/dashboard/dashboard.yaml
+++ b/dashboard/dashboard.yaml
@@ -44,32 +44,33 @@ metadata:
   namespace: kube-system
 rules:
   # Allow Dashboard to create 'kubernetes-dashboard-key-holder' secret.
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["create"]
-  # Allow Dashboard to create 'kubernetes-dashboard-settings' config map.
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["create"]
-  # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
-- apiGroups: [""]
-  resources: ["secrets"]
-  resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs"]
-  verbs: ["get", "update", "delete"]
-  # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
-- apiGroups: [""]
-  resources: ["configmaps"]
-  resourceNames: ["kubernetes-dashboard-settings"]
-  verbs: ["get", "update"]
-  # Allow Dashboard to get metrics from heapster.
-- apiGroups: [""]
-  resources: ["services"]
-  resourceNames: ["heapster"]
-  verbs: ["proxy"]
-- apiGroups: [""]
-  resources: ["services/proxy"]
-  resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
-  verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+    # Allow Dashboard to create 'kubernetes-dashboard-settings' config map.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+    # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs"]
+    verbs: ["get", "update", "delete"]
+    # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["kubernetes-dashboard-settings"]
+    verbs: ["get", "update"]
+    # Allow Dashboard to get metrics from heapster.
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["heapster"]
+    verbs: ["proxy"]
+  - apiGroups: [""]
+    resources: ["services/proxy"]
+    resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
+    verbs: ["get"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -82,15 +83,15 @@ roleRef:
   kind: Role
   name: kubernetes-dashboard-minimal
 subjects:
-- kind: ServiceAccount
-  name: kubernetes-dashboard
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: kubernetes-dashboard
+    namespace: kube-system
 
 ---
 # ------------------- Dashboard Deployment ------------------- #
 
 kind: Deployment
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
@@ -108,41 +109,41 @@ spec:
         k8s-app: kubernetes-dashboard
     spec:
       containers:
-      - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.0
-        ports:
-        - containerPort: 8443
-          protocol: TCP
-        args:
-          - --auto-generate-certificates
-          # Uncomment the following line to manually specify Kubernetes API server Host
-          # If not specified, Dashboard will attempt to auto discover the API server and connect
-          # to it. Uncomment only if the default does not work.
-          # - --apiserver-host=http://my-address:port
-        volumeMounts:
-        - name: kubernetes-dashboard-certs
-          mountPath: /certs
-          # Create on-disk volume to store exec logs
-        - mountPath: /tmp
-          name: tmp-volume
-        livenessProbe:
-          httpGet:
-            scheme: HTTPS
-            path: /
-            port: 8443
-          initialDelaySeconds: 30
-          timeoutSeconds: 30
+        - name: kubernetes-dashboard
+          image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.0
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+          args:
+            - --auto-generate-certificates
+            # Uncomment the following line to manually specify Kubernetes API server Host
+            # If not specified, Dashboard will attempt to auto discover the API server and connect
+            # to it. Uncomment only if the default does not work.
+            # - --apiserver-host=http://my-address:port
+          volumeMounts:
+            - name: kubernetes-dashboard-certs
+              mountPath: /certs
+              # Create on-disk volume to store exec logs
+            - mountPath: /tmp
+              name: tmp-volume
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /
+              port: 8443
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
       volumes:
-      - name: kubernetes-dashboard-certs
-        secret:
-          secretName: kubernetes-dashboard-certs
-      - name: tmp-volume
-        emptyDir: {}
+        - name: kubernetes-dashboard-certs
+          secret:
+            secretName: kubernetes-dashboard-certs
+        - name: tmp-volume
+          emptyDir: {}
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
 
 ---
 # ------------------- Dashboard Service ------------------- #

--- a/dashboard/heapster.yaml
+++ b/dashboard/heapster.yaml
@@ -13,17 +13,20 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
-- kind: ServiceAccount
-  name: heapster
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: heapster
+    namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: heapster
   template:
     metadata:
       labels:
@@ -32,13 +35,13 @@ spec:
     spec:
       serviceAccountName: heapster
       containers:
-      - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.5.4
-        imagePullPolicy: IfNotPresent
-        command:
-        - /heapster
-        - --source=kubernetes:https://kubernetes.default?useServiceAccount=true&kubeletHttps=true&kubeletPort=10250&insecure=true
-        - --sink=influxdb:http://monitoring-influxdb.kube-system.svc:8086
+        - name: heapster
+          image: k8s.gcr.io/heapster-amd64:v1.5.4
+          imagePullPolicy: IfNotPresent
+          command:
+            - /heapster
+            - --source=kubernetes:https://kubernetes.default?useServiceAccount=true&kubeletHttps=true&kubeletPort=10250&insecure=true
+            - --sink=influxdb:http://monitoring-influxdb.kube-system.svc:8086
 ---
 apiVersion: v1
 kind: Service
@@ -47,13 +50,13 @@ metadata:
     task: monitoring
     # For use as a Cluster add-on (https://github.com/kubernetes/kubernetes/tree/master/cluster/addons)
     # If you are NOT using this as an addon, you should comment out this line.
-    kubernetes.io/cluster-service: 'true'
+    kubernetes.io/cluster-service: "true"
     kubernetes.io/name: Heapster
   name: heapster
   namespace: kube-system
 spec:
   ports:
-  - port: 80
-    targetPort: 8082
+    - port: 80
+      targetPort: 8082
   selector:
     k8s-app: heapster

--- a/dashboard/influxdb.yaml
+++ b/dashboard/influxdb.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: monitoring-influxdb
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: influxdb
   template:
     metadata:
       labels:
@@ -12,17 +15,17 @@ spec:
         k8s-app: influxdb
     spec:
       containers:
-      - name: influxdb
-        image: k8s.gcr.io/heapster-influxdb-amd64:v1.5.2
-        env:
-        - name: INFLUXDB_BIND_ADDRESS
-          value: 127.0.0.1:8088
-        volumeMounts:
-        - mountPath: /data
-          name: influxdb-storage
+        - name: influxdb
+          image: k8s.gcr.io/heapster-influxdb-amd64:v1.5.2
+          env:
+            - name: INFLUXDB_BIND_ADDRESS
+              value: 127.0.0.1:8088
+          volumeMounts:
+            - mountPath: /data
+              name: influxdb-storage
       volumes:
-      - name: influxdb-storage
-        emptyDir: {}
+        - name: influxdb-storage
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service
@@ -31,13 +34,13 @@ metadata:
     task: monitoring
     # For use as a Cluster add-on (https://github.com/kubernetes/kubernetes/tree/master/cluster/addons)
     # If you are NOT using this as an addon, you should comment out this line.
-    kubernetes.io/cluster-service: 'true'
+    kubernetes.io/cluster-service: "true"
     kubernetes.io/name: monitoring-influxdb
   name: monitoring-influxdb
   namespace: kube-system
 spec:
   ports:
-  - port: 8086
-    targetPort: 8086
+    - port: 8086
+      targetPort: 8086
   selector:
     k8s-app: influxdb


### PR DESCRIPTION
When attempted to create UI using YAML files on k8s 1.16.2 w seeing some issues with the API Versions names and below PR fixes that.

However even after below changes and resources are created fine, UI return 404 as one of your comments say. In video

https://www.youtube.com/watch?v=brqAMyayjrI&list=PL34sAs7_26wNBRWM6BDhnonoA5FMERax0&index=7&t=1045s