### PR TITLE
Add hack required to provision K8s v1.15+ in LXC containers for insta…

### DIFF
--- a/docs/install-cluster-ubuntu-20.md
+++ b/docs/install-cluster-ubuntu-20.md
@@ -45,11 +45,20 @@ echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.
 ```
 apt update && apt install -y kubeadm=1.18.5-00 kubelet=1.18.5-00 kubectl=1.18.5-00
 ```
+
+```
+# Hack required to provision K8s v1.15+ in LXC containers
+mknod /dev/kmsg c 1 11
+echo '#!/bin/sh -e' >> /etc/rc.local
+echo 'mknod /dev/kmsg c 1 11' >> /etc/rc.local
+chmod +x /etc/rc.local
+```
+
 ## On kmaster
 ##### Initialize Kubernetes Cluster
 Update the below command with the ip address of kmaster
 ```
-kubeadm init --apiserver-advertise-address=172.16.16.100 --pod-network-cidr=192.168.0.0/16
+kubeadm init --apiserver-advertise-address=172.16.16.100 --pod-network-cidr=192.168.0.0/16  --ignore-preflight-errors=all
 ```
 ##### Deploy Calico network
 ```


### PR DESCRIPTION
…ll-cluster-ubuntu-20.md.

Hack originates from lxd-provisioning/bootstrap-kube.sh and is modified for Ubuntu.