### PR TITLE
Update nfs provisioner image

### DIFF
--- a/yamls/nfs-provisioner/deployment.yaml
+++ b/yamls/nfs-provisioner/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: nfs-client-provisioner
       containers:
         - name: nfs-client-provisioner
-          image: quay.io/external_storage/nfs-client-provisioner:latest
+          image: gcr.io/k8s-staging-sig-storage/nfs-subdir-external-provisioner:v4.0.0
           volumeMounts:
             - name: nfs-client-root
               mountPath: /persistentvolumes


### PR DESCRIPTION
The quay.io image no longer works as selfLink is now removed from Kubernetes 1.20+. There is a new image available as mentioned here: 
https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/issues/25#issuecomment-818762464 

I have tested this with 1.21.0