### PR TITLE
fix(dashboard): add missing selector field

### DIFF
--- a/dashboard/heapster.yaml
+++ b/dashboard/heapster.yaml
@@ -24,6 +24,10 @@ metadata:
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      task: monitoring
+      k8s-app: heapster
   template:
     metadata:
       labels:

--- a/dashboard/influxdb.yaml
+++ b/dashboard/influxdb.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      task: monitoring
+      k8s-app: influxdb
   template:
     metadata:
       labels:


### PR DESCRIPTION
I've just added selector field to the influxdb and heapster yaml files. Without it, I was facing this issue:

```
ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec
```