### PR TITLE
Remove hack by permanent solution for /dev/kmsg

### DIFF
--- a/lxd-provisioning/bootstrap-kube.sh
+++ b/lxd-provisioning/bootstrap-kube.sh
@@ -32,11 +32,6 @@ echo "export TERM=xterm" >> /etc/bash.bashrc
 echo "[TASK 6] Install additional packages"
 apt install -qq -y net-tools >/dev/null 2>&1
 
-# Hack required to provision K8s v1.15+ in LXC containers
-mknod /dev/kmsg c 1 11
-echo 'mknod /dev/kmsg c 1 11' >> /etc/rc.local
-chmod +x /etc/rc.local
-
 #######################################
 # To be executed only on master nodes #
 #######################################

--- a/lxd-provisioning/k8s-profile-config
+++ b/lxd-provisioning/k8s-profile-config
@@ -4,7 +4,7 @@ config:
   limits.memory.swap: "false"
   linux.kernel_modules: ip_tables,ip6_tables,nf_nat,overlay,br_netfilter
   raw.lxc: "lxc.apparmor.profile=unconfined\nlxc.cap.drop= \nlxc.cgroup.devices.allow=a\nlxc.mount.auto=proc:rw
-    sys:rw"
+    sys:rw\nlxc.mount.entry = /dev/kmsg dev/kmsg none defaults,bind,create=file"
   security.privileged: "true"
   security.nesting: "true"
 description: LXD profile for Kubernetes


### PR DESCRIPTION
The 'hack' for /dev/kmsg doesn't work anymore in Ubuntu20.04 or Debian10 images (tested both).
This mounts the /dev/kmsg with the host permanent