### PR TITLE
resolve issue with etcd service not coming up

### DIFF
--- a/kubeadm-external-etcd/1 simple-cluster.md
+++ b/kubeadm-external-etcd/1 simple-cluster.md
@@ -32,7 +32,7 @@ Description=etcd
 
 [Service]
 Type=exec
-ExecStart=/usr/local/bin/etcd \\
+ExecStart=/usr/local/bin/etcd
   --name ${ETCD_NAME} \\
   --initial-advertise-peer-urls http://${NODE_IP}:2380 \\
   --listen-peer-urls http://${NODE_IP}:2380 \\

--- a/kubeadm-external-etcd/2 simple-cluster-tls.md
+++ b/kubeadm-external-etcd/2 simple-cluster-tls.md
@@ -151,7 +151,7 @@ Description=etcd
 
 [Service]
 Type=notify
-ExecStart=/usr/local/bin/etcd \\
+ExecStart=/usr/local/bin/etcd
   --name ${ETCD_NAME} \\
   --cert-file=/etc/etcd/pki/etcd.pem \\
   --key-file=/etc/etcd/pki/etcd-key.pem \\


### PR DESCRIPTION
with line ExecStart=/usr/local/bin/etcd have extra \\\ at the end, once the service is created it fails to come with the error stated below. removing extra \\\ from the line resolve the issue and service is able to start in a normal way

![image](https://user-images.githubusercontent.com/46727623/183643696-bfc64d23-96e7-4a4b-8925-be9d45f19fef.png)
