### PR TITLE
Fix DNS and Kubeconfig vagrant-provisioning script

### DIFF
--- a/vagrant-provisioning/bootstrap.sh
+++ b/vagrant-provisioning/bootstrap.sh
@@ -5,6 +5,7 @@
 ## This script is tested only in the generic/ubuntu2204 Vagrant box
 ## If you use a different version of Ubuntu or a different Ubuntu Vagrant box test this again
 #
+DNS="1.1.1.1" ## You can change custom dns here
 
 echo "[TASK 1] Disable and turn off SWAP"
 sed -i '/swap/d' /etc/fstab
@@ -12,7 +13,7 @@ swapoff -a
 
 echo "[TASK 2] Setup DNS and Disable systemd-resolved"
 systemctl disable --now systemd-resolved
-echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+echo "nameserver $DNS" >> /etc/resolv.conf
 
 echo "[TASK 3] Stop and Disable firewall"
 systemctl disable --now ufw >/dev/null 2>&1

--- a/vagrant-provisioning/bootstrap.sh
+++ b/vagrant-provisioning/bootstrap.sh
@@ -10,10 +10,14 @@ echo "[TASK 1] Disable and turn off SWAP"
 sed -i '/swap/d' /etc/fstab
 swapoff -a
 
-echo "[TASK 2] Stop and Disable firewall"
+echo "[TASK 2] Setup DNS and Disable systemd-resolved"
+systemctl disable --now systemd-resolved
+echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+
+echo "[TASK 3] Stop and Disable firewall"
 systemctl disable --now ufw >/dev/null 2>&1
 
-echo "[TASK 3] Enable and Load Kernel modules"
+echo "[TASK 4] Enable and Load Kernel modules"
 cat >>/etc/modules-load.d/containerd.conf<<EOF
 overlay
 br_netfilter
@@ -21,7 +25,7 @@ EOF
 modprobe overlay
 modprobe br_netfilter
 
-echo "[TASK 4] Add Kernel settings"
+echo "[TASK 5] Add Kernel settings"
 cat >>/etc/sysctl.d/kubernetes.conf<<EOF
 net.bridge.bridge-nf-call-ip6tables = 1
 net.bridge.bridge-nf-call-iptables  = 1
@@ -29,7 +33,7 @@ net.ipv4.ip_forward                 = 1
 EOF
 sysctl --system >/dev/null 2>&1
 
-echo "[TASK 5] Install containerd runtime"
+echo "[TASK 6] Install containerd runtime"
 apt update -qq >/dev/null 2>&1
 apt install -qq -y ca-certificates curl gnupg lsb-release >/dev/null 2>&1
 mkdir -p /etc/apt/keyrings
@@ -44,23 +48,23 @@ sed -i 's/SystemdCgroup \= false/SystemdCgroup \= true/g' /etc/containerd/config
 systemctl restart containerd
 systemctl enable containerd >/dev/null 2>&1
 
-echo "[TASK 6] Add apt repo for kubernetes"
+echo "[TASK 7] Add apt repo for kubernetes"
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - >/dev/null 2>&1
 apt-add-repository "deb http://apt.kubernetes.io/ kubernetes-xenial main" >/dev/null 2>&1
 
-echo "[TASK 7] Install Kubernetes components (kubeadm, kubelet and kubectl)"
+echo "[TASK 8] Install Kubernetes components (kubeadm, kubelet and kubectl)"
 apt install -qq -y kubeadm=1.26.0-00 kubelet=1.26.0-00 kubectl=1.26.0-00 >/dev/null 2>&1
 
-echo "[TASK 8] Enable ssh password authentication"
+echo "[TASK 9] Enable ssh password authentication"
 sed -i 's/^PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config
 echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
 systemctl reload sshd
 
-echo "[TASK 9] Set root password"
+echo "[TASK 10] Set root password"
 echo -e "kubeadmin\nkubeadmin" | passwd root >/dev/null 2>&1
 echo "export TERM=xterm" >> /etc/bash.bashrc
 
-echo "[TASK 10] Update /etc/hosts file"
+echo "[TASK 11] Update /etc/hosts file"
 cat >>/etc/hosts<<EOF
 172.16.16.100   kmaster.example.com     kmaster
 172.16.16.101   kworker1.example.com    kworker1

--- a/vagrant-provisioning/bootstrap_kmaster.sh
+++ b/vagrant-provisioning/bootstrap_kmaster.sh
@@ -13,4 +13,5 @@ echo "[TASK 4] Generate and save cluster join command to /joincluster.sh"
 kubeadm token create --print-join-command > /joincluster.sh 2>/dev/null
 
 echo "[TASK 5] Export KUBECONFIG"
-echo "export KUBECONFIG=/etc/kubernetes/admin.conf" > /root/.bashrc
+echo "export KUBECONFIG=/etc/kubernetes/admin.conf" >> /root/.bashrc
+echo "export KUBECONFIG=/etc/kubernetes/admin.conf" >> /home/vagrant/.bashrc

--- a/vagrant-provisioning/bootstrap_kmaster.sh
+++ b/vagrant-provisioning/bootstrap_kmaster.sh
@@ -11,3 +11,6 @@ kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f https://docs.projectca
 
 echo "[TASK 4] Generate and save cluster join command to /joincluster.sh"
 kubeadm token create --print-join-command > /joincluster.sh 2>/dev/null
+
+echo "[TASK 5] Export KUBECONFIG"
+echo "export KUBECONFIG=/etc/kubernetes/admin.conf" > /root/.bashrc


### PR DESCRIPTION
I've got some problem when i run **_bootstrap.sh_** script with libvirt provider

1. VM was provisioned can't resolve domain
2. Kubeconfig file not exported automatically

First problem i fix with disable **_systemd-resolved_** and setup **_/etc/resolv.conf_** file
Second problem i fix with add **export KUBECONFIG** to **_.bashrc_** in home directory of root and vagrant user

Thank you for useful script