### PR TITLE
Update 2 simple-cluster-tls.md

### DIFF
--- a/kubeadm-external-etcd/2 simple-cluster-tls.md
+++ b/kubeadm-external-etcd/2 simple-cluster-tls.md
@@ -6,8 +6,8 @@
 ```
 {
   wget -q --show-progress \
-    https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssl \
-    https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssljson
+    https://github.com/cloudflare/cfssl/releases/download/v1.6.5/cfssl_1.6.5_linux_amd64 \
+    https://github.com/cloudflare/cfssl/releases/download/v1.6.5/cfssljson_1.6.5_linux_amd64
   
   chmod +x cfssl cfssljson
   sudo mv cfssl cfssljson /usr/local/bin/

--- a/kubeadm-external-etcd/2 simple-cluster-tls.md
+++ b/kubeadm-external-etcd/2 simple-cluster-tls.md
@@ -8,7 +8,9 @@
   wget -q --show-progress \
     https://github.com/cloudflare/cfssl/releases/download/v1.6.5/cfssl_1.6.5_linux_amd64 \
     https://github.com/cloudflare/cfssl/releases/download/v1.6.5/cfssljson_1.6.5_linux_amd64
-  
+
+  mv cfssl_1.6.5_linux_amd64 cfssl
+  mv cfssljson_1.6.5_linux_amd64 cfssljson
   chmod +x cfssl cfssljson
   sudo mv cfssl cfssljson /usr/local/bin/
 }


### PR DESCRIPTION
Added offical github download links for cfssl and cfssljson. Using the latest vresion of 1.6.5

https://github.com/cloudflare/cfssl/releases/tag/v1.6.5

The old google storage links are not working.